### PR TITLE
YAFT-64 update clogdash <parent> and pom versions to 11-SNAPSHOT

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -13,7 +13,7 @@
   	<parent>
     	<artifactId>yaft</artifactId>
     	<groupId>org.sakaiproject.yaft</groupId>
-    	<version>1.3.0-SNAPSHOT</version>
+    	<version>11-SNAPSHOT</version>
   	</parent>
   	
   	<properties>

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -14,7 +14,7 @@
   	<parent>
     	<artifactId>yaft</artifactId>
     	<groupId>org.sakaiproject.yaft</groupId>
-    	<version>1.3.0-SNAPSHOT</version>
+    	<version>11-SNAPSHOT</version>
   	</parent>
   	
   	<properties>

--- a/help/pom.xml
+++ b/help/pom.xml
@@ -13,7 +13,7 @@
   	<parent>
     	<artifactId>yaft</artifactId>
     	<groupId>org.sakaiproject.yaft</groupId>
-    	<version>1.3.0-SNAPSHOT</version>
+    	<version>11-SNAPSHOT</version>
   	</parent>
 
 	<properties>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -13,7 +13,7 @@
   	<parent>
     	<artifactId>yaft</artifactId>
     	<groupId>org.sakaiproject.yaft</groupId>
-    	<version>1.3.0-SNAPSHOT</version>
+    	<version>11-SNAPSHOT</version>
   	</parent>
   
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
   	<groupId>org.sakaiproject.yaft</groupId>
   	<artifactId>yaft</artifactId>
   	<packaging>pom</packaging>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>11-SNAPSHOT</version>
 
 	<parent>
         <groupId>org.sakaiproject</groupId>
         <artifactId>master</artifactId>
-        <version>10.0-SNAPSHOT</version>
+        <version>11-SNAPSHOT</version>
         <relativePath>../master/pom.xml</relativePath>
     </parent>
 

--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -13,7 +13,7 @@
   	<parent>
     	<artifactId>yaft</artifactId>
     	<groupId>org.sakaiproject.yaft</groupId>
-    	<version>1.3.0-SNAPSHOT</version>
+    	<version>11-SNAPSHOT</version>
   	</parent>
 
   	<dependencies>


### PR DESCRIPTION
Adrian--pointing this PR at Yaft master but before you consider merging it, I recommend creating a Yaft 1.3 (Sakai 10) branch first.  I've also updated the version from 1.3.0-SNAPSHOT to 11-SNAPSHOT.  This aligns Yaft master with Sakai trunk version practices.  However, if you would rather have clog master versioned 1.4.0-SNAPSHOT I'll happily adjust the PR.
