### PR TITLE
Always mark locked discussion with color orange

### DIFF
--- a/tool/src/webapp/css/yaft.css
+++ b/tool/src/webapp/css/yaft.css
@@ -121,10 +121,14 @@ th.yaftSortableTableHeaderSortDown {
     background-color: orange !important;
 }
 
-.yaftAlert {
-    display: none;
-    color: red;
-    font-weight: bold;
+tr.yaftInvisible td{
+	background-color: orange !important;
+}
+
+.yaftAlert{
+	display: none;
+	color: red;
+	font-weight: bold;
 }
 
 /* CLUETIP START */


### PR DESCRIPTION
This fix will mark row with orange even if it was a white row (yellow rows did work).